### PR TITLE
chore: update signingConfig for Android 14+ 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,18 +13,26 @@ android {
         targetSdk 33
         versionCode 1110
         versionName "1.11.0"
+        signingConfig signingConfigs.debug
     }
 
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.debug
         }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    dependenciesInfo {
+        includeInApk true
+        includeInBundle true
+    }
+    buildToolsVersion '33.0.2'
+    ndkVersion '25.2.9519653'
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="cu.axel.smartdock"
     tools:ignore="ProtectedPermissions,QueryAllPackagesPermission" >
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false


### PR DESCRIPTION
On Android 14+ we have troubles with including prebuilt apps as private apps. We need to update the signing config to include the updated signature requirements. 