### PR TITLE
Ignore HiddenSpace secondary display on one UI 6

### DIFF
--- a/app/src/main/java/cu/axel/smartdock/utils/DeviceUtils.kt
+++ b/app/src/main/java/cu/axel/smartdock/utils/DeviceUtils.kt
@@ -254,7 +254,12 @@ object DeviceUtils {
 
     fun getSecondaryDisplay(context: Context): Display {
         val displays = getDisplays(context)
-        return displays[displays.size - 1]
+        val display = displays[displays.size - 1]
+        if (!display.name.equals("HiddenSpace") || displays.size <= 2) {
+            return display
+        } else {
+            return displays[displays.size - 2]
+        }
     }
 
     fun getDisplayMetrics(


### PR DESCRIPTION
When mirroring screen wirelessly, two displays are created by smart view. Smart dock picks the wrong display by default. This patch fixes it. Tested and working fine on one UI 6.