### PR TITLE
Allow setting undefined windowing mode

### DIFF
--- a/app/src/main/java/cu/axel/smartdock/utils/AppUtils.kt
+++ b/app/src/main/java/cu/axel/smartdock/utils/AppUtils.kt
@@ -28,6 +28,8 @@ object AppUtils {
     const val PINNED_LIST = "pinned.lst"
     const val DOCK_PINNED_LIST = "dock_pinned.lst"
     const val DESKTOP_LIST = "desktop.lst"
+    const val WINDOWING_MODE_UNDEFINED = 0
+
     var currentApp = ""
     fun getInstalledPackages(context: Context): List<App> {
         val apps = ArrayList<App>()
@@ -369,6 +371,9 @@ object AppUtils {
 
         val windowMode: Int
         if (mode == "fullscreen") windowMode = 1
+        else if (mode == "undefined") {
+            windowMode = if (Build.VERSION.SDK_INT >= 28) WINDOWING_MODE_UNDEFINED else 1
+        }
         else {
             windowMode = if (Build.VERSION.SDK_INT >= 28) 5 else 2
             options.setLaunchBounds(

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -78,6 +78,7 @@
     <string name="maximized">Maximizado</string>
     <string name="portrait">Retrato</string>
     <string name="fullscreen">Pantalla completa</string>
+    <string name="undefined">Undefined</string>
     <string name="remember_launch_mode_title">Recordar el modo de lanzamiento</string>
     <string name="remember_launch_mode_summary">Recuerde el último modo de inicio utilizado para cada aplicación</string>
     <string name="launch_games_fullscreen_title">Iniciar juegos en pantalla completa</string>

--- a/app/src/main/res/values-pa/strings.xml
+++ b/app/src/main/res/values-pa/strings.xml
@@ -78,6 +78,7 @@
     <string name="maximized">ਵੱਧ ਤੋਂ ਵੱਧ</string>
     <string name="portrait">ਪੋਰਟਰੇਟ</string>
     <string name="fullscreen">ਪੂਰਾ ਸਕਰੀਨ</string>
+    <string name="undefined">Undefined</string>
     <string name="remember_launch_mode_title">ਲਾਂਚ ਮੋਡ ਨੂੰ ਯਾਦ ਰੱਖੋ</string>
     <string name="remember_launch_mode_summary">ਹਰ ਐਪ ਲਈ ਵਰਤੇ ਗਏ ਆਖਰੀ ਲਾਂਚ ਮੋਡ ਨੂੰ ਯਾਦ ਰੱਖੋ</string>
     <string name="launch_games_fullscreen_title">ਪੂਰੀ ਸਕ੍ਰੀਨ ਵਿੱਚ ਗੇਮਾਂ ਲਾਂਚ ਕਰੋ</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -33,12 +33,14 @@
         <item>@string/maximized</item>
         <item>@string/portrait</item>
         <item>@string/fullscreen</item>
+        <item>@string/undefined</item>
     </string-array>
     <string-array name="launch_mode_values">
         <item>standard</item>
         <item>maximized</item>
         <item>portrait</item>
         <item>fullscreen</item>
+        <item>undefined</item>
     </string-array>
 	
 	<string-array name="layouts">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
     <string name="maximized">Maximized</string>
     <string name="portrait">Portrait</string>
     <string name="fullscreen">Fullscreen</string>
+    <string name="undefined">Undefined</string>
     <string name="remember_launch_mode_title">Remember launch mode</string>
     <string name="remember_launch_mode_summary">Remember last launch mode used for every app</string>
     <string name="launch_games_fullscreen_title">Launch games in full screen</string>


### PR DESCRIPTION
I know you're busy, as you said on Telegram. When you have some free time, please have a look at this and the other PR #184.

In AOSP, there's code to persist task bounds/window size for freeform windowing mode, in desktop mode where apps open in freeform windows by default. However, Smartdock overrides this by forcibly setting its own task bounds, causing the app window size to reset every time the app is launched. This PR makes it set the launch mode to WINDOWING_MODE_UNDEFINED when the user selects "Undefined", allowing AOSP to manage the windowing mode and task bounds for the app on it's own.

Here's the link for the task bounds code if you're interested:  
https://android.googlesource.com/platform/frameworks/base/+/e6eaac80a6d4809bc94d1482a7cc23eb0288683d/services/core/java/com/android/server/wm/Task.java#1978
