### PR TITLE
Preserve app menu scroll position

### DIFF
--- a/app/src/main/java/cu/axel/smartdock/adapters/AppAdapter.kt
+++ b/app/src/main/java/cu/axel/smartdock/adapters/AppAdapter.kt
@@ -100,6 +100,13 @@ class AppAdapter(
         return apps.size
     }
 
+    fun updateApps(newApps: List<App>) {
+        this.apps = newApps
+        this.allApps.clear()
+        this.allApps.addAll(newApps)
+        notifyDataSetChanged()
+    }
+
     fun filter(query: String) {
         val results = ArrayList<App>()
         if (query.length > 1) {

--- a/app/src/main/java/cu/axel/smartdock/services/DockService.kt
+++ b/app/src/main/java/cu/axel/smartdock/services/DockService.kt
@@ -1189,10 +1189,15 @@ class DockService : AccessibilityService(), OnSharedPreferenceChangeListener, On
                 val menuFullscreen = sharedPreferences.getBoolean("app_menu_fullscreen", false)
                 val phoneLayout = sharedPreferences.getInt("dock_layout", -1) == 0
                 //TODO: Implement efficient adapter
-                appsGv.adapter = AppAdapter(
-                    context, apps, this@DockService,
-                    menuFullscreen && !phoneLayout, iconPackUtils
-                )
+                val existingAdapter = appsGv.adapter
+                if (existingAdapter is cu.axel.smartdock.adapters.AppAdapter) {
+                    existingAdapter.updateApps(apps)
+                } else {
+                    appsGv.adapter = cu.axel.smartdock.adapters.AppAdapter(
+                        context, apps, this@DockService,
+                        menuFullscreen && !phoneLayout, iconPackUtils
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
Tries to prevents the scroll position from being reset by updating the app list instead of replacing the current AppAdapter