### PR TITLE
Improve handling of app menu updates

### DIFF
--- a/app/src/main/java/cu/axel/smartdock/adapters/AppAdapter.kt
+++ b/app/src/main/java/cu/axel/smartdock/adapters/AppAdapter.kt
@@ -104,11 +104,20 @@ class AppAdapter(
         this.apps = newApps
         this.allApps.clear()
         this.allApps.addAll(newApps)
-        notifyDataSetChanged()
+        // If a query is active, re-apply it
+        if (::query.isInitialized && query.isNotEmpty()) {
+            filter(query)
+        } else {
+            this.apps = newApps
+            notifyDataSetChanged()
+        }
     }
 
     fun filter(query: String) {
         val results = ArrayList<App>()
+        if (query.isEmpty()) {
+            this.query = ""
+        }
         if (query.length > 1) {
             if (query.matches("^[0-9]+(\\.[0-9]+)?[-+/*][0-9]+(\\.[0-9]+)?".toRegex())) {
                 results.add(

--- a/app/src/main/java/cu/axel/smartdock/adapters/AppAdapter.kt
+++ b/app/src/main/java/cu/axel/smartdock/adapters/AppAdapter.kt
@@ -100,6 +100,13 @@ class AppAdapter(
         return apps.size
     }
 
+    fun updateApps(newApps: List<App>) {
+        this.apps = newApps
+        this.allApps.clear()
+        this.allApps.addAll(newApps)
+        notifyDataSetChanged()
+    }
+
     fun filter(query: String) {
         val results = ArrayList<App>()
         if (query.length > 1) {

--- a/app/src/main/java/cu/axel/smartdock/services/DockService.kt
+++ b/app/src/main/java/cu/axel/smartdock/services/DockService.kt
@@ -1189,10 +1189,15 @@ class DockService : AccessibilityService(), OnSharedPreferenceChangeListener, On
                 val menuFullscreen = sharedPreferences.getBoolean("app_menu_fullscreen", false)
                 val phoneLayout = sharedPreferences.getInt("dock_layout", -1) == 0
                 //TODO: Implement efficient adapter
-                appsGv.adapter = AppAdapter(
-                    context, apps, this@DockService,
-                    menuFullscreen && !phoneLayout, iconPackUtils
-                )
+                val existingAdapter = appsGv.adapter
+                if (existingAdapter is cu.axel.smartdock.adapters.AppAdapter) {
+                    existingAdapter.updateApps(apps)
+                } else {
+                    appsGv.adapter = cu.axel.smartdock.adapters.AppAdapter(
+                        context, apps, this@DockService,
+                        menuFullscreen && !phoneLayout, iconPackUtils
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/cu/axel/smartdock/services/DockService.kt
+++ b/app/src/main/java/cu/axel/smartdock/services/DockService.kt
@@ -1169,6 +1169,11 @@ class DockService : AccessibilityService(), OnSharedPreferenceChangeListener, On
 
     fun hideAppMenu() {
         searchEt.setText("")
+        // Reset filter
+        val adapter = appsGv.adapter
+        if (adapter is AppAdapter) {
+            adapter.filter("")
+        }
         windowManager.removeView(appMenu)
         appMenuVisible = false
     }


### PR DESCRIPTION
* Tries to prevent the scroll position from being reset by updating the app list instead of replacing the current AppAdapter
* Keeps the current search during app list updates active, and clears it on app menu exit https://github.com/axel358/smartdock/issues/169